### PR TITLE
#254 Create the config folder in the default location if not exists

### DIFF
--- a/Tools/src/main/ias-bash-profile.sh
+++ b/Tools/src/main/ias-bash-profile.sh
@@ -50,6 +50,9 @@ if [ -z "$IAS_CONFIG_FOLDER" ]; then
     export IAS_CONFIG_FOLDER=$IAS_ROOT/config
 fi
 if [ ! -d "$IAS_CONFIG_FOLDER" ]; then
+	mkdir -p "$IAS_CONFIG_FOLDER"
+fi
+if [ ! -d "$IAS_CONFIG_FOLDER" ]; then
 	echo "Warning: IAS config folder $IAS_CONFIG_FOLDER does not exist!"
 	((ERRORS_FOUND++))
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The configuration folder is now automatically created if it does not exist, preventing missing directory warnings and ensuring smoother setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->