### PR TITLE
Update README to remove 'Extras' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ The core is composed of the following modules (in order of compilation):
 * `TransferFunctions`: a collection of transfer functions
 * `SinkClient`: clients that gets IASIOs out of the BSDB and process them like the email sender
 * `Tests/SimpleLoopTest`: a module with a test
-* `Extras`: supporting tools like the cdbChecker
+


### PR DESCRIPTION
Remove mention of 'Extras' from the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated module listing in the README to reflect current product organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->